### PR TITLE
add circle-token to _isSucessfulBuild api request

### DIFF
--- a/src/services/remotes/circle-ci-service.js
+++ b/src/services/remotes/circle-ci-service.js
@@ -229,7 +229,7 @@ class CircleCIService {
     }
 
     async _isSuccessfulBuild(buildNumber) {
-        const buildResponse = await this.$httpClient.httpRequest(`https://circleci.com/api/v1.1/project/github/${this.gitRepositoryName}/${buildNumber}`);
+        const buildResponse = await this.$httpClient.httpRequest(`https://circleci.com/api/v1.1/project/github/${this.gitRepositoryName}/${buildNumber}?circle-token=${this.circleCiApiAccessToken}`);
         const build = JSON.parse(buildResponse.body);
         //  :retried, :canceled, :infrastructure_fail, :timeout, :not_run, :running, :failed, :queued, :scheduled, :not_running, :no_tests, :fixed, :success
         if (build.status === "not_running" || build.status === "queued" || build.status === "scheduled" || build.status === "running") {


### PR DESCRIPTION
Include the circleCiApiAccessToken on _isSuccessfulBuild method of circle-ci-service.

Without accessToken the api call to used to monitor the circleci build status isn't authenticated unless the repository is public.

CircleCI will respond to this request made to the api with error: "Message: Project not found". 

The error is caught and cancels the build.